### PR TITLE
Fix deprecation issue

### DIFF
--- a/src/utils/connectDatabase.ts
+++ b/src/utils/connectDatabase.ts
@@ -11,6 +11,7 @@ import debug from "./debug";
  */
 
 const connectDatabase = async (): Promise<void> => {
+  mongoose.set("strictQuery", true);
   await mongoose
     .connect(String(process.env.DATABASE_URI))
     .catch((err: unknown): void => {


### PR DESCRIPTION
I have fixed the deprecation warning issue as addressed in #5 by adding ```mongoose.set('strictQuery', true);``` to the line above the ```mongoose.connect``` function.  In theory this code would stop the deprecation waring, however it is yet to be tested on my machine.